### PR TITLE
 Add inputSchema checking to SimpleEvalFunc so the schema is checked at pig compile time, instead of run time.

### DIFF
--- a/src/java/datafu/pig/util/SimpleEvalFunc.java
+++ b/src/java/datafu/pig/util/SimpleEvalFunc.java
@@ -179,9 +179,9 @@ public abstract class SimpleEvalFunc<T> extends EvalFunc<T>
   }
 
   /**
-   * Override outputSchema so we can verify the input schema
+   * Override outputSchema so we can verify the input schema at pig compile time, instead of runtime
    * @param inputSchema input schema
-   * @return call to super.outputSchema
+   * @return call to super.outputSchema in case schema was defined elsewhere
    */
   @Override
   public Schema outputSchema(Schema inputSchema)

--- a/src/java/datafu/pig/util/SimpleEvalFunc.java
+++ b/src/java/datafu/pig/util/SimpleEvalFunc.java
@@ -202,9 +202,9 @@ public abstract class SimpleEvalFunc<T> extends EvalFunc<T>
     // check type for each argument
     for (int i=0; i < parameterTypes.length; i++) {
       try {
-        Byte inputType = inputSchema.getField(i).type;
-        Byte parameterType = DataType.findType(parameterTypes[i]);
-        if (! inputType.equals(parameterType)) {
+        byte inputType = inputSchema.getField(i).type;
+        byte parameterType = DataType.findType(parameterTypes[i]);
+        if (inputType != parameterType) {
           throw new IllegalArgumentException(String.format("%s: argument type mismatch [#%d]; expected %s, got %s",
                                                            _method_signature(),
                                                            i+1,


### PR DESCRIPTION
I added input type validation at pig compile time instead of run time by overriding the outputSchema() method.  Let me know if I need to write more unit tests to cover this code.
