### PR TITLE
Fixed StreamingQuantile.outputSchema so that it conforms to the real output

### DIFF
--- a/src/java/datafu/pig/stats/StreamingQuantile.java
+++ b/src/java/datafu/pig/stats/StreamingQuantile.java
@@ -248,9 +248,8 @@ public class StreamingQuantile extends SimpleEvalFunc<Tuple> implements Accumula
   public Schema outputSchema(Schema input)
   {
     Schema tupleSchema = new Schema();
-    for (int i = 0; i < numQuantiles; i++) {
-      tupleSchema.add(new Schema.FieldSchema("quantile_" + i, DataType.DOUBLE));
-    }
+    for (Double x : this.quantiles)
+      tupleSchema.add(new Schema.FieldSchema("quantile_" + x.toString().replace(".", "_"), DataType.DOUBLE));
     return tupleSchema;
   }
 


### PR DESCRIPTION
The StreamingQuantile UDF generates intermediary quantiles but outputs only the request quantiles. However, the outputSchema method does not reflect that. So the following Pig script breaks with an incompatible schema error:

define Quantiles datafu.pig.stats.StreamingQuantile('0.5', '0.9', '0.95', '1');
A = foreach B generate flatten(Quantiles(B.C)) as (q1, q2, q3, q4);

I changed the outputSchema so that only the requested quantiles are in the schema.
