### PR TITLE
TotalTimeBetween UDF

### DIFF
--- a/src/java/datafu/pig/bags/TotalTimeBetween.java
+++ b/src/java/datafu/pig/bags/TotalTimeBetween.java
@@ -24,7 +24,7 @@ import org.joda.time.format.ISODateTimeFormat;
  * 
  * Example:
  * {@code
- * DEFINE TotalTime datafu.pig.bags.TotalTime();
+ * DEFINE TotalTimeBetween datafu.pig.bags.TotalTimeBetween();
  * 
  * -- input: 
  * -- 2012-01-01T00:00:00\tbiuA8n98wn\thttp://www.google.com/

--- a/src/java/datafu/pig/bags/TotalTimeBetween.java
+++ b/src/java/datafu/pig/bags/TotalTimeBetween.java
@@ -1,0 +1,94 @@
+package datafu.pig.bags;
+
+import java.io.IOException;
+
+import org.apache.pig.Accumulator;
+import org.apache.pig.EvalFunc;
+import org.apache.pig.backend.executionengine.ExecException;
+import org.apache.pig.data.DataBag;
+import org.apache.pig.data.DataType;
+import org.apache.pig.data.Tuple;
+import org.apache.pig.impl.logicalLayer.schema.Schema;
+import org.joda.time.DateTime;
+import org.joda.time.Seconds;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+
+
+/**
+ * This UDF takes an input bag which is assumed to be ordered by
+ * an ISO8601 timestamp field and returns the total time elapsed
+ * (in seconds) by all tuples in the bag.  The first field in 
+ * each of the tuples in the DataBag is assumed to be the ISO8601
+ * timestamp.
+ * 
+ * Example:
+ * {@code
+ * DEFINE TotalTime datafu.pig.bags.TotalTime();
+ * 
+ * -- input: 
+ * -- 2012-01-01T00:00:00\tbiuA8n98wn\thttp://www.google.com/
+ * -- 2012-01-01T00:00:00\tasd909m09j\thttp://www.google.com/
+ * -- 2012-01-01T00:01:00\tbiuA8n98wn\thttp://www.google.com/1
+ * -- 2012-01-01T00:01:05\tbiuA8n98wn\thttp://www.google.com/
+ * -- 2012-01-01T00:02:00\tasd909m09j\thttp://www.google.com/2
+ * input = LOAD 'input' AS (timestamp:chararray, visitor_id:chararray, url:chararray);
+ * by_visitor = GROUP data BY visitor_id;
+ * count_time = FOREACH by_visitor &#123;
+ *   ordered = ORDER data BY timestamp ASC;
+ *   GENERATE group, TotalTimeBetween(ordered);
+ * &#125;;
+ * DUMP count_time;
+ * -- (biuA8n98wn,65)
+ * -- (asd909m09j,120)
+ * }
+ * 
+ *
+ */
+public class TotalTimeBetween extends EvalFunc<Long> implements Accumulator<Long> {
+  
+  private DateTime intermediateLastTime;
+  private long intermediateTimeInSeconds;
+  private DateTimeFormatter isoParser;
+  
+  public TotalTimeBetween() {
+    isoParser = ISODateTimeFormat.dateTimeParser();
+    cleanup();
+  }
+  
+  public void cleanup() {
+    intermediateTimeInSeconds = 0L;
+    intermediateLastTime = null;
+  }
+
+  public Long exec(Tuple inputTuple) throws IOException {
+    accumulate(inputTuple);
+    long timeInSeconds = getValue();
+    cleanup();
+    
+    return timeInSeconds;
+  }
+  
+  public void accumulate(Tuple inputTuple) throws ExecException {
+    DataBag inputBag = (DataBag)inputTuple.get(0);
+    for (Tuple t : inputBag) {
+      DateTime tupleTime = isoParser.parseDateTime((String) t.get(0));
+      if (intermediateLastTime == null) {
+        intermediateLastTime = tupleTime;
+        continue;
+      }
+      
+      intermediateTimeInSeconds += Seconds.secondsBetween(intermediateLastTime, tupleTime).getSeconds();
+      intermediateLastTime = tupleTime;
+    }
+  }
+  
+  public Long getValue() {
+    return intermediateTimeInSeconds;
+  }
+  
+  @Override
+  public Schema outputSchema(Schema input) {
+    return new Schema(new Schema.FieldSchema(null, DataType.LONG));
+  }
+}

--- a/test/pig/datafu/test/pig/bags/BagTests.java
+++ b/test/pig/datafu/test/pig/bags/BagTests.java
@@ -409,4 +409,23 @@ public class BagTests extends PigTests
     assertOutput(test, "data3",
         "({(A,3),(B,2),(C,1)})");
   }
+  
+  @Test
+  public void totalTimeBetweenTest() throws Exception
+  {
+    PigTest test = createPigTest("test/pig/datafu/test/pig/bags/totalTimeBetweenTest.pig");
+    
+    writeLinesToFile("input",
+        "2012-01-01T00:00:00\tbiuA8n98wn\thttp://www.google.com/",
+        "2012-01-01T00:00:00\tasd909m09j\thttp://www.google.com/",
+        "2012-01-01T00:01:00\tbiuA8n98wn\thttp://www.google.com/1",
+        "2012-01-01T00:01:05\tbiuA8n98wn\thttp://www.google.com/",
+        "2012-01-01T00:02:00\tasd909m09j\thttp://www.google.com/2");
+    
+    test.runScript();
+    
+    assertOutput(test, "ordered_time",
+        "(biuA8n98wn,65)",
+        "(asd909m09j,120)");
+  }
 }

--- a/test/pig/datafu/test/pig/bags/totalTimeBetweenTest.pig
+++ b/test/pig/datafu/test/pig/bags/totalTimeBetweenTest.pig
@@ -1,0 +1,16 @@
+register $JAR_PATH
+
+define TotalTimeBetween datafu.pig.bags.TotalTimeBetween();
+
+data = LOAD 'input' AS (timestamp:chararray, visitor_id:chararray, url:chararray);
+
+by_visitor = GROUP data BY visitor_id;
+
+count_time = FOREACH by_visitor {
+    ordered = ORDER data BY timestamp ASC;
+    GENERATE group, TotalTimeBetween(ordered);
+};
+
+ordered_time = ORDER count_time BY $1 ASC;
+
+STORE ordered_time INTO 'output';


### PR DESCRIPTION
This UDF takes an input bag which is assumed to be ordered by an ISO8601 timestamp field and returns the total time elapsed (in seconds) by all tuples in the bag.  The first field in each of the tuples in the DataBag is assumed to be the ISO8601 timestamp.

**Example:**

```
 DEFINE TotalTimeBetween datafu.pig.bags.TotalTimeBetween();

-- input: 
-- 2012-01-01T00:00:00\tbiuA8n98wn\thttp://www.google.com/
-- 2012-01-01T00:00:00\tasd909m09j\thttp://www.google.com/
-- 2012-01-01T00:01:00\tbiuA8n98wn\thttp://www.google.com/1
-- 2012-01-01T00:01:05\tbiuA8n98wn\thttp://www.google.com/
-- 2012-01-01T00:02:00\tasd909m09j\thttp://www.google.com/2
input = LOAD 'input' AS (timestamp:chararray, visitor_id:chararray, url:chararray);
by_visitor = GROUP data BY visitor_id;
count_time = FOREACH by_visitor {
    ordered = ORDER data BY timestamp ASC;
    GENERATE group, TotalTimeBetween(ordered);
};
DUMP count_time;
-- (biuA8n98wn,65)
-- (asd909m09j,120)
```

In truth I wasn't really sure what to call / where to put this UDF so I'm open to suggestions.
