### PR TITLE
Make Quantile output schemas consistent with StreamingQuantile

### DIFF
--- a/src/java/datafu/pig/stats/QuantileUtil.java
+++ b/src/java/datafu/pig/stats/QuantileUtil.java
@@ -19,6 +19,19 @@ import java.util.ArrayList;
 
 public class QuantileUtil
 { 
+  public static ArrayList<Double> getNQuantiles(int numQuantiles)
+  {
+    ArrayList<Double> quantiles = new ArrayList<Double>(numQuantiles);
+    quantiles = new ArrayList<Double>(numQuantiles);
+    int divisor = numQuantiles-1;
+    for (int q = 0; q <= divisor; q++)
+    {
+      double quantile = ((double)q)/divisor;
+      quantiles.add(quantile);
+    }
+    return quantiles;
+  }
+  
   public static ArrayList<Double> getQuantilesFromParams(String... k)
   {
     ArrayList<Double> quantiles = new ArrayList<Double>(k.length);
@@ -34,13 +47,7 @@ public class QuantileUtil
         throw new IllegalArgumentException("Number of quantiles must be greater than 1");
       }
       
-      quantiles = new ArrayList<Double>(numQuantiles);
-      int divisor = numQuantiles-1;
-      for (int q = 0; q <= divisor; q++)
-      {
-        double quantile = ((double)q)/divisor;
-        quantiles.add(quantile);
-      }
+      quantiles = getNQuantiles(numQuantiles);
     }
     else
     {


### PR DESCRIPTION
These two UDFs were inconsistent in how they named the output quantiles.  The convention of StreamingQuantile actually made more sense, so standardizing on that.

The convention:
- If you request specific quantiles, the output quantiles will be named based on this.  For example, 0.5 yields quantile_0_5.
- If you request n quantiles, then the output quantiles will be labeled 0..(n-1).  For example, 3 yields quantile_0, quantile_1, and quantile_3.

Previously if you requested 3 for Quantile you would get 0_0, 0_5, and 1_0.  The problem with this convention is that if you requested many quantiles, e.g. 1000, it's hard to know what the names will be.  But if you request 1000 you can at least be sure that quantile_499, quantile_500, etc. exist.

Also added test cases which check the output schema by using FOREACH..GENERATE on the names.
