### PR TITLE
Add Nondeterministic annotation where appropriate

### DIFF
--- a/src/java/datafu/pig/sampling/ReservoirSample.java
+++ b/src/java/datafu/pig/sampling/ReservoirSample.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import org.apache.pig.AccumulatorEvalFunc;
 import org.apache.pig.Algebraic;
 import org.apache.pig.EvalFunc;
+import org.apache.pig.builtin.Nondeterministic;
 import org.apache.pig.data.BagFactory;
 import org.apache.pig.data.DataBag;
 import org.apache.pig.data.DataType;
@@ -37,6 +38,7 @@ import org.apache.pig.impl.logicalLayer.schema.Schema;
  * @author wvaughan
  *
  */
+@Nondeterministic
 public class ReservoirSample extends AccumulatorEvalFunc<DataBag> implements Algebraic
 {
   Integer numSamples;

--- a/src/java/datafu/pig/sampling/WeightedSample.java
+++ b/src/java/datafu/pig/sampling/WeightedSample.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.Random;
 
 import org.apache.pig.EvalFunc;
+import org.apache.pig.builtin.Nondeterministic;
 import org.apache.pig.data.BagFactory;
 import org.apache.pig.data.DataBag;
 import org.apache.pig.data.DataType;
@@ -56,6 +57,7 @@ import org.apache.pig.impl.logicalLayer.schema.Schema;
  * }
  * </pre>
  */
+@Nondeterministic
 public class WeightedSample extends EvalFunc<DataBag>
 {
   BagFactory bagFactory = BagFactory.getInstance();

--- a/src/java/datafu/pig/sessions/Sessionize.java
+++ b/src/java/datafu/pig/sessions/Sessionize.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 import org.apache.pig.Accumulator;
 import org.apache.pig.AccumulatorEvalFunc;
 import org.apache.pig.EvalFunc;
+import org.apache.pig.builtin.Nondeterministic;
 import org.apache.pig.data.BagFactory;
 import org.apache.pig.data.DataBag;
 import org.apache.pig.data.DataType;
@@ -68,6 +69,7 @@ import org.joda.time.Period;
  * </pre>
  * </p>
  */
+@Nondeterministic
 public class Sessionize extends AccumulatorEvalFunc<DataBag>
 {
   private final long millis;


### PR DESCRIPTION
As njwhite raised, need to add Nondeterministic annotation for UDFs which don't produce deterministic output.

WeightedSample is actually deterministic with a seed provided, however to be on the safe side this marks the UDF as non-deterministic.  Perhaps we can split into two versions.
