### PR TITLE
Coalesce should merge types where possible, add EmptyBagToNull

### DIFF
--- a/src/java/datafu/pig/bags/EmptyBagToNull.java
+++ b/src/java/datafu/pig/bags/EmptyBagToNull.java
@@ -1,0 +1,43 @@
+package datafu.pig.bags;
+
+import java.io.IOException;
+
+import org.apache.pig.EvalFunc;
+import org.apache.pig.data.DataBag;
+import org.apache.pig.data.Tuple;
+import org.apache.pig.impl.logicalLayer.schema.Schema;
+
+/**
+ * Returns null if the input is an empty bag; otherwise,
+ * returns the input bag unchanged.
+ */
+public class EmptyBagToNull extends EvalFunc<DataBag>
+{
+  @Override
+  public DataBag exec(Tuple tuple) throws IOException
+  {
+    if (tuple.size() == 0 || tuple.get(0) == null)
+      return null;
+    Object o = tuple.get(0);
+    if (o instanceof DataBag)
+    {
+      DataBag bag = (DataBag)o;
+      if (bag.size() == 0)
+      {
+        return null;
+      }
+      else
+      {
+        return bag;
+      }
+    }
+    else
+      throw new IllegalArgumentException("expected a null or a bag");
+  }
+
+  @Override
+  public Schema outputSchema(Schema input)
+  {
+    return input;
+  }
+}

--- a/test/pig/datafu/test/pig/bags/BagTests.java
+++ b/test/pig/datafu/test/pig/bags/BagTests.java
@@ -63,6 +63,44 @@ public class BagTests extends PigTests
   /**
   register $JAR_PATH
 
+  define EmptyBagToNull datafu.pig.bags.EmptyBagToNull();
+  
+  data = LOAD 'input' AS (B: bag {T: tuple(v:INT)});
+  
+  dump data;
+  
+  data2 = FOREACH data GENERATE EmptyBagToNull(B) as P;
+  
+  dump data2;
+  
+  STORE data2 INTO 'output';
+   */
+  @Multiline
+  private String emptyBagToNullTest;
+  
+  @Test
+  public void emptyBagToNullTest() throws Exception
+  {
+    PigTest test = createPigTestFromString(emptyBagToNullTest);
+            
+    writeLinesToFile("input", 
+                     "({(1),(2),(3),(4),(5)})",
+                     "()",
+                     "({})",
+                     "{(4),(5)})");
+            
+    test.runScript();
+        
+    assertOutput(test, "data2",
+                 "({(1),(2),(3),(4),(5)})",
+                 "()",
+                 "()",
+                 "({(4),(5)})");
+  }
+  
+  /**
+  register $JAR_PATH
+
   define AppendToBag datafu.pig.bags.AppendToBag();
   
   data = LOAD 'input' AS (key:INT, B: bag{T: tuple(v:INT)}, T: tuple(v:INT));

--- a/test/pig/datafu/test/pig/util/CoalesceTests.java
+++ b/test/pig/datafu/test/pig/util/CoalesceTests.java
@@ -118,31 +118,146 @@ public class CoalesceTests extends PigTests
   
   /**
   register $JAR_PATH
-  
+
   define COALESCE datafu.pig.util.Coalesce();
   
-  data = LOAD 'input' using PigStorage(',') AS (testcase:INT,val1:INT,val2:DOUBLE);
+  data = LOAD 'input' using PigStorage(',') AS (testcase:INT,val1:LONG);
   
-  data2 = FOREACH data GENERATE testcase, COALESCE(val1,val2) as result;
+  data2 = FOREACH data GENERATE testcase, COALESCE(val1,100) as result;
   
   describe data2;
   
   data3 = FOREACH data2 GENERATE testcase, result;
   
-  STORE data3 INTO 'output';
-  */
-  @Multiline private static String coalesceDiffTypesTest;
+  data4 = FOREACH data3 GENERATE testcase, result*100 as result;
   
-  @Test(expectedExceptions=FrontendException.class)
-  public void coalesceDiffTypesTest() throws Exception
+  STORE data4 INTO 'output';
+  */
+  @Multiline private static String coalesceIntAndLongTest;
+  
+  // The first parameter is a long and the fixed value is an int.
+  // They are merged to a long.
+  @Test
+  public void coalesceCastIntToLongTest1() throws Exception
   {
-    PigTest test = createPigTestFromString(coalesceDiffTypesTest);
+    PigTest test = createPigTestFromString(coalesceIntAndLongTest);
     
-    this.writeLinesToFile("input", "1,1,2.0");
+    this.writeLinesToFile("input", "1,5",
+                                   "2,");
     
     test.runScript();
     
-    this.getLinesForAlias(test, "data3");
+    List<Tuple> lines = this.getLinesForAlias(test, "data4");
+    
+    Assert.assertEquals(2, lines.size());
+    for (Tuple t : lines)
+    {
+      switch((Integer)t.get(0))
+      {
+      case 1:
+        Assert.assertEquals(500L, t.get(1)); break;
+      case 2:
+        Assert.assertEquals(10000L, t.get(1)); break;
+      default:
+        Assert.fail("Did not expect: " + t.get(1));                    
+      }
+    }
+  }
+  
+  /**
+  register $JAR_PATH
+
+  define COALESCE datafu.pig.util.Coalesce();
+  
+  data = LOAD 'input' using PigStorage(',') AS (testcase:INT,val1:INT);
+  
+  data2 = FOREACH data GENERATE testcase, COALESCE(val1,100L) as result;
+  
+  describe data2;
+  
+  data3 = FOREACH data2 GENERATE testcase, result;
+  
+  data4 = FOREACH data3 GENERATE testcase, result*100 as result;
+  
+  STORE data4 INTO 'output';
+  */
+  @Multiline private static String coalesceIntAndLongTest2;
+  
+  // The first parameter is an int, but the fixed parameter is a long.
+  // They are merged to a long.
+  @Test
+  public void coalesceCastIntToLongTest2() throws Exception
+  {
+    PigTest test = createPigTestFromString(coalesceIntAndLongTest2);
+    
+    this.writeLinesToFile("input", "1,5",
+                                   "2,");
+    
+    test.runScript();
+    
+    List<Tuple> lines = this.getLinesForAlias(test, "data4");
+    
+    Assert.assertEquals(2, lines.size());
+    for (Tuple t : lines)
+    {
+      switch((Integer)t.get(0))
+      {
+      case 1:
+        Assert.assertEquals(500L, t.get(1)); break;
+      case 2:
+        Assert.assertEquals(10000L, t.get(1)); break;
+      default:
+        Assert.fail("Did not expect: " + t.get(1));                    
+      }
+    }
+  }
+  
+  /**
+  register $JAR_PATH
+
+  define COALESCE datafu.pig.util.Coalesce();
+  
+  data = LOAD 'input' using PigStorage(',') AS (testcase:INT,val1:INT);
+  
+  data2 = FOREACH data GENERATE testcase, COALESCE(val1,100.0) as result;
+  
+  describe data2;
+  
+  data3 = FOREACH data2 GENERATE testcase, result;
+  
+  data4 = FOREACH data3 GENERATE testcase, result*100 as result;
+  
+  STORE data4 INTO 'output';
+  */
+  @Multiline private static String coalesceIntAndDoubleTest;
+  
+  // The first parameter is an int, but the fixed parameter is a long.
+  // They are merged to a long.
+  @Test
+  public void coalesceCastIntToDoubleTest() throws Exception
+  {
+    PigTest test = createPigTestFromString(coalesceIntAndDoubleTest);
+    
+    this.writeLinesToFile("input", "1,5",
+                                   "2,");
+    
+    test.runScript();
+    
+    List<Tuple> lines = this.getLinesForAlias(test, "data4");
+    
+    Assert.assertEquals(2, lines.size());
+    for (Tuple t : lines)
+    {
+      switch((Integer)t.get(0))
+      {
+      case 1:
+        Assert.assertEquals(500.0, t.get(1)); break;
+      case 2:
+        Assert.assertEquals(10000.0, t.get(1)); break;
+      default:
+        Assert.fail("Did not expect: " + t.get(1));                    
+      }
+    }
   }
   
   /**
@@ -160,12 +275,12 @@ public class CoalesceTests extends PigTests
   
   STORE data3 INTO 'output';
   */
-  @Multiline private static String coalesceBagTypeTest;
+  @Multiline private static String coalesceBagIncompatibleTypeTest;
   
   @Test(expectedExceptions=FrontendException.class)
-  public void coalesceBagTypeTest() throws Exception
+  public void coalesceBagIncompatibleTypeTest() throws Exception
   {
-    PigTest test = createPigTestFromString(coalesceBagTypeTest);
+    PigTest test = createPigTestFromString(coalesceBagIncompatibleTypeTest);
     
     this.writeLinesToFile("input", "1,1,{(2)}");
     

--- a/test/pig/datafu/test/pig/util/CoalesceTests.java
+++ b/test/pig/datafu/test/pig/util/CoalesceTests.java
@@ -9,6 +9,7 @@ import org.apache.pig.data.Tuple;
 import org.apache.pig.impl.logicalLayer.FrontendException;
 import org.apache.pig.pigunit.PigTest;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.testng.annotations.Test;
 
 import datafu.test.pig.PigTests;
@@ -328,8 +329,6 @@ public class CoalesceTests extends PigTests
   */
   @Multiline private static String coalesceCastIntToDatetimeTest;
   
-  // The first parameter is an int, but the fixed parameter is a long.
-  // They are merged to a long.
   @Test
   public void coalesceCastIntToDatetimeTest() throws Exception
   {
@@ -350,7 +349,7 @@ public class CoalesceTests extends PigTests
       switch(testcase)
       {
       case 1:
-        Assert.assertEquals("2013-08-06T14:56:23.000-07:00", t.get(1).toString()); break;
+        Assert.assertEquals("2013-08-06T21:56:23.000Z", ((DateTime)t.get(1)).toDateTime(DateTimeZone.UTC).toString()); break;
       case 2:
         Assert.assertEquals("1970-01-01T00:00:00.000Z", t.get(1).toString()); break;
       default:
@@ -378,8 +377,6 @@ public class CoalesceTests extends PigTests
   */
   @Multiline private static String coalesceCastIntToDatetimeLazyTest;
   
-  // The first parameter is an int, but the fixed parameter is a long.
-  // They are merged to a long.
   @Test
   public void coalesceCastIntToDatetimeLazyTest() throws Exception
   {
@@ -400,7 +397,7 @@ public class CoalesceTests extends PigTests
       switch(testcase)
       {
       case 1:
-        Assert.assertEquals("2013-08-06T14:56:23.000-07:00", t.get(1).toString()); break;
+        Assert.assertEquals("2013-08-06T21:56:23.000Z", ((DateTime)t.get(1)).toDateTime(DateTimeZone.UTC).toString()); break;
       case 2:
         Assert.assertEquals("1970-01-01T00:00:00.000Z", t.get(1).toString()); break;
       default:


### PR DESCRIPTION
When using Coalesce on many fields it can be annoying to have to know whether, for example, the field is an int or a long.  For example:

```
 Coalesce(val1,0L) as val1,
 Coalesce(val2,0L) as val2,
 Coalesce(val3,0L) as val3,
 Coalesce(val4,0L) as val4,
```

Suppose that among val1,val2,val3,val4, some are ints and some are longs.  In this situation we may choose to make all types long for simplicity.  Before this change this would fail, because int and long are different.

This adds a 'lazy' mode to Coalesce, where it tries to merge types if possible when there is incompatibility, and the value will be cast to this type.  The default is 'strict' mode.

I also added EmptyBagToNull, which is especially useful at performing a "left join" using COGROUP:

```
result = FOREACH (COGROUP data_1 by id,data_2 BY id,data_3 BY id,data_4 BY id) generate 
FLATTEN(data_1), -- left joining on this, flattening an empty bag removes the row
FLATTEN(EmptyBagToNull(data_2)),
FLATTEN(EmptyBagToNull(data_3)),
FLATTEN(EmptyBagToNull(data_4));
```
