### PR TITLE
Add EmptyBagToNullFields

### DIFF
--- a/src/java/datafu/pig/bags/CountEach.java
+++ b/src/java/datafu/pig/bags/CountEach.java
@@ -19,9 +19,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.pig.Accumulator;
 import org.apache.pig.AccumulatorEvalFunc;
-import org.apache.pig.EvalFunc;
 import org.apache.pig.data.BagFactory;
 import org.apache.pig.data.DataBag;
 import org.apache.pig.data.DataType;

--- a/src/java/datafu/pig/bags/DistinctBy.java
+++ b/src/java/datafu/pig/bags/DistinctBy.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.util.HashSet;
 
 import org.apache.pig.AccumulatorEvalFunc;
-import org.apache.pig.EvalFunc;
 import org.apache.pig.backend.executionengine.ExecException;
 import org.apache.pig.data.BagFactory;
 import org.apache.pig.data.DataBag;

--- a/src/java/datafu/pig/bags/EmptyBagToNullFields.java
+++ b/src/java/datafu/pig/bags/EmptyBagToNullFields.java
@@ -1,0 +1,77 @@
+package datafu.pig.bags;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.apache.pig.EvalFunc;
+import org.apache.pig.data.BagFactory;
+import org.apache.pig.data.DataBag;
+import org.apache.pig.data.DataType;
+import org.apache.pig.data.Tuple;
+import org.apache.pig.data.TupleFactory;
+import org.apache.pig.impl.logicalLayer.FrontendException;
+import org.apache.pig.impl.logicalLayer.schema.Schema;
+
+import datafu.pig.util.AliasableEvalFunc;
+
+/**
+ * For an empty bag, inserts a tuple having null values for all fields; 
+ * otherwise, the input bag is returned unchanged.
+ * 
+ * <p>
+ * This can be useful when performing FLATTEN on a bag from a COGROUP,
+ * as FLATTEN on an empty bag produces no data.
+ * </p>
+ */
+public class EmptyBagToNullFields extends AliasableEvalFunc<DataBag>
+{
+  @Override
+  public DataBag exec(Tuple tuple) throws IOException
+  {
+    if (tuple.size() == 0 || tuple.get(0) == null)
+      return null;
+    Object o = tuple.get(0);
+    if (o instanceof DataBag)
+    {
+      DataBag bag = (DataBag)o;
+      if (bag.size() == 0)
+      {
+        // create a tuple with null values for all fields
+        int tupleSize = (Integer)getInstanceProperties().get("tuplesize");
+        return BagFactory.getInstance().newDefaultBag(Arrays.asList(TupleFactory.getInstance().newTuple(tupleSize)));
+      }
+      else
+      {
+        return bag;
+      }
+    }
+    else
+      throw new IllegalArgumentException("expected a null or a bag");
+  }
+
+  @Override
+  public Schema getOutputSchema(Schema input)
+  {
+    try
+    {
+      if (input.size() != 1)
+      {
+        throw new RuntimeException("Expected only a single field as input");
+      }
+      
+      if (input.getField(0).type != DataType.BAG)
+      {
+        throw new RuntimeException("Expected a BAG as input, but found " + DataType.findTypeName(input.getField(0).type));
+      }
+      
+      // get the size of the tuple within the bag
+      int innerTupleSize = input.getField(0).schema.getField(0).schema.getFields().size();
+      getInstanceProperties().put("tuplesize", innerTupleSize);
+    }
+    catch (FrontendException e)
+    {
+      throw new RuntimeException(e);
+    }
+    return input;
+  }
+}

--- a/src/java/datafu/pig/bags/EmptyBagToNullFields.java
+++ b/src/java/datafu/pig/bags/EmptyBagToNullFields.java
@@ -3,7 +3,6 @@ package datafu.pig.bags;
 import java.io.IOException;
 import java.util.Arrays;
 
-import org.apache.pig.EvalFunc;
 import org.apache.pig.data.BagFactory;
 import org.apache.pig.data.DataBag;
 import org.apache.pig.data.DataType;
@@ -12,7 +11,7 @@ import org.apache.pig.data.TupleFactory;
 import org.apache.pig.impl.logicalLayer.FrontendException;
 import org.apache.pig.impl.logicalLayer.schema.Schema;
 
-import datafu.pig.util.AliasableEvalFunc;
+import datafu.pig.util.ContextualEvalFunc;
 
 /**
  * For an empty bag, inserts a tuple having null values for all fields; 
@@ -23,7 +22,7 @@ import datafu.pig.util.AliasableEvalFunc;
  * as FLATTEN on an empty bag produces no data.
  * </p>
  */
-public class EmptyBagToNullFields extends AliasableEvalFunc<DataBag>
+public class EmptyBagToNullFields extends ContextualEvalFunc<DataBag>
 {
   @Override
   public DataBag exec(Tuple tuple) throws IOException
@@ -50,7 +49,7 @@ public class EmptyBagToNullFields extends AliasableEvalFunc<DataBag>
   }
 
   @Override
-  public Schema getOutputSchema(Schema input)
+  public Schema outputSchema(Schema input)
   {
     try
     {

--- a/src/java/datafu/pig/bags/Enumerate.java
+++ b/src/java/datafu/pig/bags/Enumerate.java
@@ -18,7 +18,6 @@ package datafu.pig.bags;
 
 import java.io.IOException;
 
-import org.apache.pig.Accumulator;
 import org.apache.pig.AccumulatorEvalFunc;
 import org.apache.pig.data.BagFactory;
 import org.apache.pig.data.DataBag;
@@ -27,8 +26,6 @@ import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
 import org.apache.pig.impl.logicalLayer.FrontendException;
 import org.apache.pig.impl.logicalLayer.schema.Schema;
-
-import datafu.pig.util.SimpleEvalFunc;
 
 /**
  * Enumerate a bag, appending to each tuple its index within the bag.

--- a/src/java/datafu/pig/bags/UnorderedPairs.java
+++ b/src/java/datafu/pig/bags/UnorderedPairs.java
@@ -25,7 +25,6 @@ import org.apache.pig.data.DataType;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
 import org.apache.pig.impl.logicalLayer.schema.Schema;
-import org.apache.pig.impl.util.WrappedIOException;
 import org.apache.pig.tools.pigstats.PigStatusReporter;
 
 import com.google.common.collect.ImmutableList;
@@ -91,7 +90,7 @@ public class UnorderedPairs extends EvalFunc<DataBag>
       return outputBag;
     }
     catch (Exception e) {
-      throw WrappedIOException.wrap("Caught exception processing input of " + this.getClass().getName(), e);
+      throw new RuntimeException("Caught exception processing input of " + this.getClass().getName(), e);
     }
   }
 

--- a/src/java/datafu/pig/util/ContextualEvalFunc.java
+++ b/src/java/datafu/pig/util/ContextualEvalFunc.java
@@ -1,0 +1,64 @@
+package datafu.pig.util;
+
+import java.util.Properties;
+
+import org.apache.pig.EvalFunc;
+import org.apache.pig.impl.util.UDFContext;
+
+/**
+ * An abstract class which enables UDFs to store instance properties
+ * on the front end which will be available on the back end.
+ * For example, properties may be set in the call to outputSchema(),
+ * which will be available when exec() is called.
+ * 
+ * @param <T>
+ */
+public abstract class ContextualEvalFunc<T> extends EvalFunc<T>
+{
+  private String instanceName;
+  
+  @Override
+  public void setUDFContextSignature(String signature) {
+    setInstanceName(signature);
+  }
+  
+  /**
+   * Helper method to return the context properties for this class
+   * 
+   * @return context properties
+   */
+  protected Properties getContextProperties() {
+    UDFContext context = UDFContext.getUDFContext();
+    Properties properties = context.getUDFProperties(this.getClass());
+    return properties;
+  }
+  
+  /**
+   * Helper method to return the context properties for this instance of this class
+   * 
+   * @return instances properties
+   */
+  protected Properties getInstanceProperties() {
+    Properties contextProperties = getContextProperties();
+    if (!contextProperties.containsKey(getInstanceName())) {
+      contextProperties.put(getInstanceName(), new Properties());
+    }
+    return (Properties)contextProperties.get(getInstanceName());
+  }
+  
+  /**
+   * 
+   * @return the name of this instance corresponding to the UDF Context Signature
+   * @see #setUDFContextSignature(String)
+   */
+  protected String getInstanceName() {
+    if (instanceName == null) {
+      throw new RuntimeException("Instance name is null.  This should not happen unless UDFContextSignature was not set.");
+    }
+    return instanceName;
+  }
+  
+  private void setInstanceName(String instanceName) {
+    this.instanceName = instanceName;
+  }
+}

--- a/src/java/datafu/pig/util/DataFuException.java
+++ b/src/java/datafu/pig/util/DataFuException.java
@@ -1,0 +1,103 @@
+package datafu.pig.util;
+
+import java.util.Map;
+
+public class DataFuException extends RuntimeException
+{
+  private static final long serialVersionUID = 1L;
+  private Map<String, Integer> fieldAliases;
+  private Object data;
+  
+  public DataFuException()
+  {
+    super();
+  }
+  
+  public DataFuException(String message)
+  {
+    super(message);    
+  }
+  
+  public DataFuException(String message, Throwable cause)
+  {
+    super(message, cause);    
+  }
+  
+  public DataFuException(Throwable cause)
+  {
+    super(cause);    
+  }
+
+  /**
+   * Gets field aliases for a UDF which may be relevant to this exception.
+   * 
+   * @return field aliases
+   */
+  public Map<String, Integer> getFieldAliases()
+  {
+    return fieldAliases;
+  }
+
+  /**
+   * Gets data relevant to this exception.
+   * 
+   * @return data
+   */
+  public Object getData()
+  {
+    return data;
+  }
+
+  /**
+   * Sets field aliases for a UDF which may be relevant to this exception.
+   * 
+   * @param fieldAliases
+   */
+  public void setFieldAliases(Map<String, Integer> fieldAliases)
+  {
+    this.fieldAliases = fieldAliases;
+  }
+
+  /**
+   * Sets data relevant to this exception.
+   * @param data
+   */
+  public void setData(Object data)
+  {
+    this.data = data;
+  }  
+  
+  @Override
+  public String toString()
+  {
+    String s = getClass().getName();
+    String message = getLocalizedMessage();
+    
+    StringBuilder result = new StringBuilder(s);
+    
+    if (message != null)
+    {
+      result.append(": ");
+      result.append(message);
+    }
+    
+    if (getFieldAliases() != null)
+    {
+      result.append("\nAliases:");
+      for (String alias : getFieldAliases().keySet())
+      {
+        result.append("\n");
+        result.append(alias != null && alias.length() > 0 ? alias : "???");
+      }
+    }
+    
+    if (getData() != null)
+    {
+      result.append("\nData:");
+      result.append("\n");
+      result.append(data.toString());
+    }
+    
+    return result.toString();
+  }
+}

--- a/test/pig/datafu/test/pig/bags/BagTests.java
+++ b/test/pig/datafu/test/pig/bags/BagTests.java
@@ -101,6 +101,42 @@ public class BagTests extends PigTests
   /**
   register $JAR_PATH
 
+  define EmptyBagToNullFields datafu.pig.bags.EmptyBagToNullFields();
+  
+  data = LOAD 'input' AS (B: bag {T: tuple(v1:INT,v2:INT)});
+  
+  dump data;
+  
+  data2 = FOREACH data GENERATE EmptyBagToNullFields(B) as P;
+  
+  dump data2;
+  
+  STORE data2 INTO 'output';
+   */
+  @Multiline
+  private String emptyBagToNullFieldsTest;
+  
+  @Test
+  public void emptyBagToNullFieldsTest() throws Exception
+  {
+    PigTest test = createPigTestFromString(emptyBagToNullFieldsTest);
+            
+    writeLinesToFile("input", 
+                     "({(1,1),(2,2),(3,3),(4,4),(5,5)})",
+                     "({})",
+                     "{(4,4),(5,5)})");
+            
+    test.runScript();
+        
+    assertOutput(test, "data2",
+                 "({(1,1),(2,2),(3,3),(4,4),(5,5)})",
+                 "({(,)})",
+                 "({(4,4),(5,5)})");
+  }
+  
+  /**
+  register $JAR_PATH
+
   define AppendToBag datafu.pig.bags.AppendToBag();
   
   data = LOAD 'input' AS (key:INT, B: bag{T: tuple(v:INT)}, T: tuple(v:INT));

--- a/test/pig/datafu/test/pig/util/CoalesceTests.java
+++ b/test/pig/datafu/test/pig/util/CoalesceTests.java
@@ -411,7 +411,7 @@ public class CoalesceTests extends PigTests
   
   define COALESCE datafu.pig.util.Coalesce();
   
-  data = LOAD 'input' using PigStorage(',') AS (testcase:INT,val1:INT,val2: bag {tuple(aVal:int)});
+  data = LOAD 'input' using PigStorage(',') AS (testcase:INT,val1:INT,val2:LONG);
   
   data2 = FOREACH data GENERATE testcase, COALESCE(val1,val2) as result;
   
@@ -428,7 +428,7 @@ public class CoalesceTests extends PigTests
   {
     PigTest test = createPigTestFromString(coalesceBagIncompatibleTypeTest);
     
-    this.writeLinesToFile("input", "1,1,{(2)}");
+    this.writeLinesToFile("input", "1,1,2L}");
     
     test.runScript();
     


### PR DESCRIPTION
Besides the test for EmptyBagToNullFields, also add a "leftJoinTest" which uses a COGROUP and FLATTEN to perform a left join with multiple variables.  It turns out that EmptyBagToNull can't be used to fix the "flattening empty bag produces no results" issue.  The desired behavior when flattening the null value would be would be for pig to return a tuple having null fields, but instead it just produces a null value.  EmptyBagToNullFields fixes this problem, making it possible to do the left join operation.
