### PR TITLE
Allow overriding java source and target version via properties

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -51,6 +51,7 @@
   <property name="output.jarfile.javadoc" value="${dist.dir}/${final.name}-javadoc.jar" />
   
   <property name="testclasses.pattern" value="**/*.class" />
+  <property name="test.methods" value="" />
       
   <property name="ivy.jar.dir" value="${basedir}/ivy" />
   <property name="datafu.pom.name" value="pom.xml" />
@@ -317,7 +318,7 @@
   
   <target name="test" depends="build-pig-tests, jar" description="Runs the pig tests">
     <taskdef resource="testngtasks" classpath="${common.lib.dir}/testng-jar-6.2.jar"/>
-    <testng classpathref="test-classpath"
+    <testng classpathref="test-classpath" methods="${test.methods}"
             outputDir="${report.dir}" verbose="2" haltonfailure="true" haltonskipped="true">
       <jvmarg value="-Xmx1G" />
       <sysproperty key="datafu.jar.dir" value="${dist.dir}" />
@@ -327,7 +328,7 @@
   
   <target name="test-instrumented" depends="build-pig-tests, jar-instrumented" description="Runs the tests with instrumented JARs">
     <taskdef resource="testngtasks" classpath="${common.lib.dir}/testng-6.2.jar"/>
-    <testng classpathref="instrumented-test-classpath"
+    <testng classpathref="instrumented-test-classpath" methods="${test.methods}"
             outputDir="${report.dir}" haltonfailure="true" haltonskipped="true">
       <jvmarg value="-Xmx1G" />
       <sysproperty key="datafu.jar.dir" value="${instrumented.dir}" />

--- a/build.xml
+++ b/build.xml
@@ -40,7 +40,11 @@
   <property name="instrumented.dir" value="${basedir}/instrumented" />
   <property name="pigtestclasses.dir" value="${dist.dir}/pigtestclasses" />
   <property name="fastutil.jar" value="fastutil-jar-6.3.jar" />
-  
+
+  <!-- Java configuration -->
+  <property name="targetJavaVersion" value="1.5" />
+  <property name="sourceJavaVersion" value="${targetJavaVersion}" />
+
   <!-- output names -->
   <property name="output.jarfile" value="${dist.dir}/${final.name}.jar" />
   <property name="output.jarfile.sources" value="${dist.dir}/${final.name}-sources.jar" />
@@ -207,7 +211,7 @@
   
   <target name="build" depends="init" description="Compile main source tree java files">
     <replace-dir dir="${classes.dir}" />
-    <javac destdir="${classes.dir}" target="1.5" debug="true" deprecation="false" failonerror="true" includeantruntime="false">
+    <javac destdir="${classes.dir}" source="${sourceJavaVersion}" target="${targetJavaVersion}" debug="true" deprecation="false" failonerror="true" includeantruntime="false">
       <src path="${java.dir}" />
       <exclude name="datafu/linkedin/**"/>
       <classpath refid="main-classpath" />
@@ -216,7 +220,7 @@
 
   <target name="build-plugins" depends="init" description="Compile main source tree java files">
     <replace-dir dir="${plugin.classes.dir}" />
-    <javac destdir="${plugin.classes.dir}" target="1.5" debug="true" deprecation="false" failonerror="true" includeantruntime="false">
+    <javac destdir="${plugin.classes.dir}" source="${sourceJavaVersion}" target="${targetJavaVersion}" debug="true" deprecation="false" failonerror="true" includeantruntime="false">
       <src path="${plugin.java.dir}" />
       <classpath refid="plugin-classpath" />
     </javac>
@@ -239,7 +243,7 @@
         <exclude name="**/*.java" />
       </fileset>
     </copy>
-    <javac destdir="${pigtestclasses.dir}" target="1.5" debug="true" deprecation="false" failonerror="true" includeantruntime="false">
+    <javac destdir="${pigtestclasses.dir}" source="${sourceJavaVersion}" target="${targetJavaVersion}" debug="true" deprecation="false" failonerror="true" includeantruntime="false">
       <src path="${pigtestsrc.dir}" />
       <compilerarg line="-processor org.adrianwalker.multilinestring.MultilineProcessor"/>
       <classpath refid="test-classpath" />

--- a/ivy.xml
+++ b/ivy.xml
@@ -6,31 +6,31 @@
     </configurations>
     <dependencies>
       
-        <dependency org="org.apache.pig" name="pig" rev="0.11.1" conf="common->default">
+        <dependency org="org.apache.pig" name="pig" rev="${pig.version}" conf="common->default">
           <!-- pig 0.10.0 pom lists wrong version of avro -->
           <exclude org="org.apache.hadoop" name="avro" />
         </dependency>
 
-        <dependency org="org.apache.pig" name="pigunit" rev="0.11.1" conf="common->default"/>
+        <dependency org="org.apache.pig" name="pigunit" rev="${pig.version}" conf="common->default"/>
         
         <!-- use the right avro version which pig 0.10.0 was built against -->
-        <dependency org="org.apache.avro" name="avro" rev="1.5.3" conf="common->default"/>
+        <dependency org="org.apache.avro" name="avro" rev="${avro.version}" conf="common->default"/>
         
-        <dependency org="it.unimi.dsi" name="fastutil" rev="6.3" conf="common->default"/>
-        <dependency org="joda-time" name="joda-time" rev="1.6" conf="common->default"/>
-        <dependency org="org.apache.commons" name="commons-math" rev="2.1" conf="common->default"/>
-        <dependency org="commons-io" name="commons-io" rev="1.4" conf="common->default"/>
-        <dependency org="org.apache.hadoop" name="hadoop-core" rev="0.20.2" conf="common->default"/>
-        <dependency org="org.testng" name="testng" rev="6.2" conf="common->default"/>
-        <dependency org="com.google.guava" name="guava" rev="11.0" conf="common->default"/>
+        <dependency org="it.unimi.dsi" name="fastutil" rev="${fastutil.version}" conf="common->default"/>
+        <dependency org="joda-time" name="joda-time" rev="${joda-time.version}" conf="common->default"/>
+        <dependency org="org.apache.commons" name="commons-math" rev="${commons-math.version}" conf="common->default"/>
+        <dependency org="commons-io" name="commons-io" rev="${commons-io.version}" conf="common->default"/>
+        <dependency org="org.apache.hadoop" name="hadoop-core" rev="${hadoop.version}" conf="common->default"/>
+        <dependency org="org.testng" name="testng" rev="${testng.version}" conf="common->default"/>
+        <dependency org="com.google.guava" name="guava" rev="${guava.version}" conf="common->default"/>
           
         <!-- needed for pigunit to work -->
-        <dependency org="log4j" name="log4j" rev="1.2.14" conf="common->default"/>
-        <dependency org="jline" name="jline" rev="0.9.94" conf="common->default"/>
-        <dependency org="org.antlr" name="antlr" rev="3.2" conf="common->default"/>
+        <dependency org="log4j" name="log4j" rev="${log4j.version}" conf="common->default"/>
+        <dependency org="jline" name="jline" rev="${jline.version}" conf="common->default"/>
+        <dependency org="org.antlr" name="antlr" rev="${antlr.version}" conf="common->default"/>
 
-        <dependency org="org.apache.maven" name="maven-ant-tasks" rev="2.1.3" conf="common->default" />
+        <dependency org="org.apache.maven" name="maven-ant-tasks" rev="${maven.version}" conf="common->default" />
         
-        <dependency org="com.sun" name="tools" rev="1.4.2" conf="tools->default"/>
+        <dependency org="com.sun" name="tools" rev="${tools.version}" conf="tools->default"/>
     </dependencies>
 </ivy-module>

--- a/ivy/libraries.properties
+++ b/ivy/libraries.properties
@@ -1,1 +1,15 @@
+antlr.version=3.2
+avro.version=1.5.3
+commons-math.version=2.1
+commons-io.version=1.4
+fastutil.version=6.3
+guava.version=11.0
+hadoop.version=0.20.2
+joda-time.version=1.6
+log4j.version=1.2.14
+maven.version=2.1.3
+jline.version=0.9.94
+pig.version=0.11.1
+testng.version=6.2
+tools.version=1.4.2
 wagon-http.version=1.0-beta-2

--- a/src/java/datafu/pig/stats/Quantile.java
+++ b/src/java/datafu/pig/stats/Quantile.java
@@ -25,7 +25,9 @@ import org.apache.pig.data.DataBag;
 import org.apache.pig.data.DataType;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
+import org.apache.pig.impl.logicalLayer.FrontendException;
 import org.apache.pig.impl.logicalLayer.schema.Schema;
+import org.apache.pig.impl.logicalLayer.schema.Schema.FieldSchema;
 
 import datafu.pig.util.SimpleEvalFunc;
 
@@ -192,7 +194,12 @@ public class Quantile extends SimpleEvalFunc<Tuple>
       for (Double x : this.quantiles)
         tupleSchema.add(new Schema.FieldSchema("quantile_" + x.toString().replace(".", "_"), DataType.DOUBLE));
     }
-    return tupleSchema;
+
+    try {
+      return new Schema(new FieldSchema(null, tupleSchema, DataType.TUPLE));
+    } catch(FrontendException e) {
+      throw new RuntimeException(e);
+    }
   }
 }
 

--- a/src/java/datafu/pig/stats/StreamingQuantile.java
+++ b/src/java/datafu/pig/stats/StreamingQuantile.java
@@ -26,7 +26,9 @@ import org.apache.pig.data.DataBag;
 import org.apache.pig.data.DataType;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
+import org.apache.pig.impl.logicalLayer.FrontendException;
 import org.apache.pig.impl.logicalLayer.schema.Schema;
+import org.apache.pig.impl.logicalLayer.schema.Schema.FieldSchema;
 
 import com.google.common.collect.Lists;
 
@@ -259,7 +261,12 @@ public class StreamingQuantile extends AccumulatorEvalFunc<Tuple>
       for (Double x : this.quantiles)
         tupleSchema.add(new Schema.FieldSchema("quantile_" + x.toString().replace(".", "_"), DataType.DOUBLE));
     }
-    return tupleSchema;
+
+    try {
+      return new Schema(new FieldSchema(null, tupleSchema, DataType.TUPLE));
+    } catch(FrontendException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   static class QuantileEstimator

--- a/src/java/datafu/pig/stats/WilsonBinConf.java
+++ b/src/java/datafu/pig/stats/WilsonBinConf.java
@@ -24,7 +24,9 @@ import org.apache.commons.math.distribution.NormalDistributionImpl;
 import org.apache.pig.data.DataType;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
+import org.apache.pig.impl.logicalLayer.FrontendException;
 import org.apache.pig.impl.logicalLayer.schema.Schema;
+import org.apache.pig.impl.logicalLayer.schema.Schema.FieldSchema;
 
 import com.google.common.collect.ImmutableList;
 
@@ -125,8 +127,14 @@ public class WilsonBinConf extends SimpleEvalFunc<Tuple>
   @Override
   public Schema outputSchema(Schema input)
   {
-    return new Schema(ImmutableList.of(
-            new Schema.FieldSchema("lower", DataType.DOUBLE),
-            new Schema.FieldSchema("upper", DataType.DOUBLE)));
+    try {
+      Schema innerSchema =  new  Schema(ImmutableList.of(
+              new Schema.FieldSchema("lower", DataType.DOUBLE),
+              new Schema.FieldSchema("upper", DataType.DOUBLE)));
+
+      return new Schema(new FieldSchema(null, innerSchema, DataType.TUPLE));
+    } catch(FrontendException e) {
+      throw new RuntimeException(e);
+    }
   }
 }


### PR DESCRIPTION
I've moved the hard coded target version to a property, so that the default behavior will remain the same. However user will have ability to override the target version via the property on command line, for example:

ant clean jar -DtargetJavaVersion=1.7
