### PR TITLE
Finish support for Pig 0.12

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,6 +1,7 @@
 Azarias Reda
 Cheolsoo Park
 Evion Kim
+Jarek Jarcec Cecho
 Josh Wills
 Matt Hayes
 Mitul Tiwari

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ processing data in Hadoop.
 
 ## Pig Compatibility
 
-The current version of DataFu has been tested against Pig 0.11.1.  DataFu should be compatible with some older versions of Pig, however
+The current version of DataFu has been tested against Pig 0.11.1 and 0.12.0.  DataFu should be compatible with some older versions of Pig, however
 we do not do any sort of testing with prior versions of Pig and do not guarantee compatibility.  
 Our policy is to test against the most recent version of Pig whenever we release and make sure DataFu works with that version. 
 

--- a/src/java/datafu/pig/util/Assert.java
+++ b/src/java/datafu/pig/util/Assert.java
@@ -22,46 +22,13 @@ import org.apache.pig.FilterFunc;
 import org.apache.pig.data.Tuple;
 
 /**
- * Filter function which asserts that a value is true.
+ * Assert has been renamed to AssertUDF.
  * 
- * <p>
- * Unfortunately, the Pig interpreter doesn't recognize boolean expressions nested as function
- * arguments, so this uses C-style booleans.  That is, the first argument should be
- * an integer.  0 is interpreted as "false", and anything else is considered "true".
- * The function will cause the Pig script to fail if a "false" value is encountered.
- * </p>
- * 
- * <p>
- * There is a unary and a binary version. The unary version just takes a boolean, and throws out a generic exception message when the
- * assertion is violated.  The binary version takes a String as a second argument and throws that out when the assertion
- * is violated.
- * </p>
- * 
- * <p>
- * Example:
- * <pre>
- * {@code
- * FILTER members BY ASSERT( (member_id >= 0 ? 1 : 0), 'Doh! Some member ID is negative.' );
- * }
- * </pre>
- * </p>
+ * This class is provided for backward compatibility.
+ *
+ * @deprecated Use {@link AssertUDF()} instead.
  */
-public class Assert extends FilterFunc
+ @Deprecated
+public class Assert extends AssertUDF
 {
-  @Override
-  public Boolean exec(Tuple tuple)
-      throws IOException
-  {
-    if ((Integer) tuple.get(0) == 0) {
-      if (tuple.size() > 1) {
-        throw new IOException("Assertion violated: " + tuple.get(1).toString());
-      }
-      else {
-        throw new IOException("Assertion violated.  What assertion, I do not know, but it was officially violated.");
-      }
-    }
-    else {
-      return true;
-    }
-  }
 }

--- a/src/java/datafu/pig/util/AssertUDF.java
+++ b/src/java/datafu/pig/util/AssertUDF.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2010 LinkedIn, Inc
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+ 
+package datafu.pig.util;
+
+import java.io.IOException;
+
+import org.apache.pig.FilterFunc;
+import org.apache.pig.data.Tuple;
+
+/**
+ * Filter function which asserts that a value is true.
+ * 
+ * <p>
+ * Unfortunately, the Pig interpreter doesn't recognize boolean expressions nested as function
+ * arguments, so this uses C-style booleans.  That is, the first argument should be
+ * an integer.  0 is interpreted as "false", and anything else is considered "true".
+ * The function will cause the Pig script to fail if a "false" value is encountered.
+ * </p>
+ * 
+ * <p>
+ * There is a unary and a binary version. The unary version just takes a boolean, and throws out a generic exception message when the
+ * assertion is violated.  The binary version takes a String as a second argument and throws that out when the assertion
+ * is violated.
+ * </p>
+ * 
+ * <p>
+ * Example:
+ * <pre>
+ * {@code
+ * FILTER members BY ASSERT( (member_id >= 0 ? 1 : 0), 'Doh! Some member ID is negative.' );
+ * }
+ * </pre>
+ * </p>
+ */
+public class AssertUDF extends FilterFunc
+{
+  @Override
+  public Boolean exec(Tuple tuple)
+      throws IOException
+  {
+    if ((Integer) tuple.get(0) == 0) {
+      if (tuple.size() > 1) {
+        throw new IOException("Assertion violated: " + tuple.get(1).toString());
+      }
+      else {
+        throw new IOException("Assertion violated.  What assertion, I do not know, but it was officially violated.");
+      }
+    }
+    else {
+      return true;
+    }
+  }
+}

--- a/src/java/datafu/pig/util/In.java
+++ b/src/java/datafu/pig/util/In.java
@@ -6,41 +6,13 @@ import org.apache.pig.FilterFunc;
 import org.apache.pig.data.Tuple;
 
 /**
- * Similar to the SQL IN function, this function provides a convenient way to filter 
- * using a logical disjunction over many values. 
- * Returns true when the first value of the tuple is contained within the remainder of the tuple.
+ * In has been renamed to InUDF.
  * 
- * <p>
- * Example:
- * <pre>
- * {@code
- * define In datafu.pig.util.In();
- * -- cars: (alice, red), (bob, blue), (charlie, green), (dave, red);
- * cars = LOAD cars AS (owner:chararray, color:chararray);
- * 
- * -- cars: (alice, red), (bob, blue), (dave, red);
- * red_blue_cars = FILTER cars BY In(color, 'red', 'blue');
- * 
- * }</pre>
- * </p>
- * 
- * @author wvaughan
+ * This class is provided for backward compatibility.
  *
+ * @deprecated Use {@link InUDF()} instead.
  */
-public class In extends FilterFunc
+ @Deprecated
+public class In extends InUDF
 {
-
-  @Override
-  public Boolean exec(Tuple input) throws IOException
-  {
-    Object o = input.get(0);
-    Boolean match = false;
-    if (o != null) {
-      for (int i=1; i<input.size() && !match; i++) {
-        match = match || o.equals(input.get(i));
-      }
-    }    
-    return match;
-  }
-
 }

--- a/src/java/datafu/pig/util/InUDF.java
+++ b/src/java/datafu/pig/util/InUDF.java
@@ -1,0 +1,46 @@
+package datafu.pig.util;
+
+import java.io.IOException;
+
+import org.apache.pig.FilterFunc;
+import org.apache.pig.data.Tuple;
+
+/**
+ * Similar to the SQL IN function, this function provides a convenient way to filter 
+ * using a logical disjunction over many values. 
+ * Returns true when the first value of the tuple is contained within the remainder of the tuple.
+ * 
+ * <p>
+ * Example:
+ * <pre>
+ * {@code
+ * define In datafu.pig.util.In();
+ * -- cars: (alice, red), (bob, blue), (charlie, green), (dave, red);
+ * cars = LOAD cars AS (owner:chararray, color:chararray);
+ * 
+ * -- cars: (alice, red), (bob, blue), (dave, red);
+ * red_blue_cars = FILTER cars BY In(color, 'red', 'blue');
+ * 
+ * }</pre>
+ * </p>
+ * 
+ * @author wvaughan
+ *
+ */
+public class InUDF extends FilterFunc
+{
+
+  @Override
+  public Boolean exec(Tuple input) throws IOException
+  {
+    Object o = input.get(0);
+    Boolean match = false;
+    if (o != null) {
+      for (int i=1; i<input.size() && !match; i++) {
+        match = match || o.equals(input.get(i));
+      }
+    }    
+    return match;
+  }
+
+}

--- a/test/pig/datafu/test/pig/util/AssertTests.java
+++ b/test/pig/datafu/test/pig/util/AssertTests.java
@@ -17,11 +17,11 @@ public class AssertTests extends PigTests
   /**
   register $JAR_PATH
   
-  define ASSERT datafu.pig.util.Assert();
+  define ASRT datafu.pig.util.AssertUDF();
   
   data = LOAD 'input' AS (val:INT);
   
-  data2 = FILTER data BY ASSERT(val,'assertion appears to have failed, doh!');
+  data2 = FILTER data BY ASRT(val,'assertion appears to have failed, doh!');
   
   STORE data2 INTO 'output';
   */
@@ -65,11 +65,11 @@ public class AssertTests extends PigTests
   /**
   register $JAR_PATH
   
-  define ASSERT datafu.pig.util.Assert();
+  define ASRT datafu.pig.util.AssertUDF();
   
   data = LOAD 'input' AS (val:INT);
   
-  data2 = FILTER data BY ASSERT(val);
+  data2 = FILTER data BY ASRT(val);
   
   STORE data2 INTO 'output';
   */

--- a/test/pig/datafu/test/pig/util/InTests.java
+++ b/test/pig/datafu/test/pig/util/InTests.java
@@ -11,12 +11,12 @@ public class InTests extends PigTests
   /**
   register $JAR_PATH
 
-  define In datafu.pig.util.In();
+  define I datafu.pig.util.InUDF();
   
   data = LOAD 'input' AS (B: bag {T: tuple(v:INT)});
   
   data2 = FOREACH data {
-    C = FILTER B By In(v, 1,2,3);
+    C = FILTER B By I(v, 1,2,3);
     GENERATE C;
   }
   
@@ -47,12 +47,12 @@ public class InTests extends PigTests
   /**
   register $JAR_PATH
 
-  define In datafu.pig.util.In();
+  define I datafu.pig.util.InUDF();
   
   data = LOAD 'input' AS (B: bag {T: tuple(v:chararray)});
   
   data2 = FOREACH data {
-    C = FILTER B By In(v, 'will','matt','sam');
+    C = FILTER B By I(v, 'will','matt','sam');
     GENERATE C;
   }
   
@@ -83,11 +83,11 @@ public class InTests extends PigTests
   /**
   register $JAR_PATH
   
-  define In datafu.pig.util.In();
+  define I datafu.pig.util.InUDF();
   
   data = LOAD 'input' AS (owner:chararray, color:chararray);
   describe data;
-  data2 = FILTER data BY In(color, 'red','blue');
+  data2 = FILTER data BY I(color, 'red','blue');
   describe data2;
   STORE data2 INTO 'output';
   */


### PR DESCRIPTION
Pig 0.12.0 has added several new keywords such as "Assert" or "In" (via PIG-3367 and PIG-3269). This is causing issues to DataFu UDFs with the same name. I wasn't able to find any other solution other then renaming the UDFs in question. I do understand that this is very intrusive change, so I've provided deprecated ones for backward compatibility - e.g users on Pig 0.11.0 will still be able to use the Assert or In as they are now.

After applying this final set of changes I was able to run all unit tests against Pig 0.12.0 without any issues!
