### PR TITLE
The gitignore file has "lib/".

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ annotation-plugin.jar
 .classpath
 docs/
 input
-lib/
+/lib/
 report/
 ivy/*.jar
 ivy/pom.xml


### PR DESCRIPTION
The gitignore file has "lib/".

That means that any path to a file in the repository that contained "lib"
in it, wouldn't be tracked by git.

It sounds like the intent of the .gitignore file may not be matching
the results. "lib" is a common word that occurs in path names and without
this patch, anything under a path that contains a directory named "lib"
will be ignored.

This patch changes the gitignore file so only the contents under a directory
called lib in the root of the repository is ignored.
