### PR TITLE
Remove requirement to include Guava JAR

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -47,6 +47,7 @@
   <property name="pigtestclasses.dir" value="${dist.dir}/pigtestclasses" />
   <property name="fastutil.jar" value="fastutil-jar-${fastutil.version}.jar" />
   <property name="commons-math.jar" value="commons-math-jar-${commons-math.version}.jar" />
+  <property name="guava.jar" value="guava-jar-${guava.version}.jar" />
   <property name="stream.jar" value="stream-jar-${stream.version}.jar" />
 
   <!-- Java configuration -->
@@ -327,13 +328,22 @@
           </not>
       </condition>
     </fail>
+    <fail message="Could not find guava jar">
+      <condition>
+          <not>
+              <resourcecount count="1">
+                  <fileset id="fs" dir="${packaged.lib.dir}" includes="${guava.jar}"/>
+              </resourcecount>
+          </not>
+      </condition>
+    </fail>
     
     <!-- add fastutil classes to the core jar -->
     <echo message="Adding to ${final.name}.jar with autojar" />
     <delete file="${dist.dir}/${final.name}-orig.jar" />
     <move file="${dist.dir}/${final.name}.jar" tofile="${dist.dir}/${final.name}-orig.jar" />
     <java jar="${tools.dir}/autojar.jar" fork="true">
-      <arg line="-baeq -o ${dist.dir}/${final.name}.jar -c ${packaged.lib.dir}/${fastutil.jar}:${packaged.lib.dir}/${commons-math.jar}:${packaged.lib.dir}/${stream.jar} ${dist.dir}/${final.name}-orig.jar" />
+      <arg line="-baeq -o ${dist.dir}/${final.name}.jar -c ${packaged.lib.dir}/${fastutil.jar}:${packaged.lib.dir}/${commons-math.jar}:${packaged.lib.dir}/${stream.jar}:${packaged.lib.dir}/${guava.jar} ${dist.dir}/${final.name}-orig.jar" />
     </java>
     <delete file="${dist.dir}/${final.name}-orig.jar" />
     
@@ -346,6 +356,7 @@
         <rule pattern="it.unimi.dsi.fastutil.**" result="datafu.it.unimi.dsi.fastutil.@1"/>
         <rule pattern="org.apache.commons.math.**" result="datafu.org.apache.commons.math.@1"/>
         <rule pattern="com.clearspring.analytics.**" result="datafu.com.clearspring.analytics.@1"/>
+        <rule pattern="com.google.common.**" result="datafu.com.google.common.@1"/>
     </jarjar>
     <delete file="${dist.dir}/${final.name}-orig.jar" />
   </target>

--- a/ivy.xml
+++ b/ivy.xml
@@ -10,8 +10,7 @@
     <dependencies>      
 
         <!-- dependencies explicitly listed in the pom that are required -->        
-        <dependency org="joda-time" name="joda-time" rev="${joda-time.version}" conf="common->default"/>
-        <dependency org="com.google.guava" name="guava" rev="${guava.version}" conf="common->default"/>         
+        <dependency org="joda-time" name="joda-time" rev="${joda-time.version}" conf="common->default"/>  
 
         <!-- dependencies that are packaged within the datafu jar and are therefore not listed in the pom -->
         <dependency org="it.unimi.dsi" name="fastutil" rev="${fastutil.version}" conf="packaged->default"/>
@@ -20,6 +19,7 @@
             <!-- don't include fastutil, as we will include it below and don't want it in the common directory -->
             <exclude org="it.unimi.dsi" name="fastutil" />
         </dependency>
+        <dependency org="com.google.guava" name="guava" rev="${guava.version}" conf="packaged->default"/>       
 
         <!-- hadoop and pig dependencies required for building but which are not included in the pom because
              we don't want to require a specific version -->

--- a/ivy/pom-template.xml
+++ b/ivy/pom-template.xml
@@ -65,10 +65,5 @@
       <artifactId>joda-time</artifactId>
       <version>1.6</version>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>11.0</version>
-    </dependency>
   </dependencies>
 </project>

--- a/src/java/datafu/pig/bags/UnorderedPairs.java
+++ b/src/java/datafu/pig/bags/UnorderedPairs.java
@@ -17,6 +17,7 @@
 package datafu.pig.bags;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import org.apache.pig.EvalFunc;
 import org.apache.pig.data.BagFactory;
@@ -26,8 +27,6 @@ import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
 import org.apache.pig.impl.logicalLayer.schema.Schema;
 import org.apache.pig.tools.pigstats.PigStatusReporter;
-
-import com.google.common.collect.ImmutableList;
 
 /**
  * Generates pairs of all items in a bag.
@@ -70,7 +69,7 @@ public class UnorderedPairs extends EvalFunc<DataBag>
           j = 0; 
           for (Tuple elem2 : inputBag) {
             if (j > i) {
-              outputBag.add(tupleFactory.newTuple(ImmutableList.of(elem1, elem2)));
+              outputBag.add(tupleFactory.newTuple(Arrays.asList(elem1, elem2)));
               cnt++;
             }
             j++;

--- a/src/java/datafu/pig/stats/MarkovPairs.java
+++ b/src/java/datafu/pig/stats/MarkovPairs.java
@@ -18,6 +18,7 @@ package datafu.pig.stats;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 
 import org.apache.pig.EvalFunc;
 import org.apache.pig.backend.executionengine.ExecException;
@@ -28,8 +29,6 @@ import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
 import org.apache.pig.impl.logicalLayer.schema.Schema;
 import org.apache.pig.impl.logicalLayer.schema.Schema.FieldSchema;
-
-import com.google.common.collect.ImmutableList;
 
 
 /**
@@ -79,7 +78,7 @@ public class MarkovPairs extends EvalFunc<DataBag>
           outputBag.spill();
           count = 0;
         }
-        outputBag.add(tupleFactory.newTuple(ImmutableList.of(elem1, elem2)));
+        outputBag.add(tupleFactory.newTuple(Arrays.asList(elem1, elem2)));
         count ++;
       }
     }

--- a/src/java/datafu/pig/stats/StreamingQuantile.java
+++ b/src/java/datafu/pig/stats/StreamingQuantile.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
-import org.apache.pig.Accumulator;
 import org.apache.pig.AccumulatorEvalFunc;
 import org.apache.pig.data.DataBag;
 import org.apache.pig.data.DataType;
@@ -29,10 +28,6 @@ import org.apache.pig.data.TupleFactory;
 import org.apache.pig.impl.logicalLayer.FrontendException;
 import org.apache.pig.impl.logicalLayer.schema.Schema;
 import org.apache.pig.impl.logicalLayer.schema.Schema.FieldSchema;
-
-import com.google.common.collect.Lists;
-
-import datafu.pig.util.SimpleEvalFunc;
 
 /**
  * Computes approximate {@link <a href="http://en.wikipedia.org/wiki/Quantile" target="_blank">quantiles</a>} 
@@ -273,7 +268,7 @@ public class StreamingQuantile extends AccumulatorEvalFunc<Tuple>
   {
     private static final long MAX_TOT_ELEMS = 1024L * 1024L * 1024L * 1024L;
 
-    private final List<List<Double>> buffer = Lists.newArrayList();
+    private final List<List<Double>> buffer = new ArrayList<List<Double>>();
     private final int numQuantiles;
     private final int maxElementsPerBuffer;
     private int totalElements;
@@ -302,7 +297,7 @@ public class StreamingQuantile extends AccumulatorEvalFunc<Tuple>
         buffer.add(null);
       }
       if (buffer.get(level) == null) {
-        buffer.set(level, Lists.<Double>newArrayList());
+        buffer.set(level, new ArrayList<Double>());
       }
     }
     
@@ -334,7 +329,7 @@ public class StreamingQuantile extends AccumulatorEvalFunc<Tuple>
       if (buffer.get(level + 1).isEmpty()) {
         merged = buffer.get(level + 1);
       } else {
-        merged = Lists.newArrayListWithCapacity(maxElementsPerBuffer);
+        merged = new ArrayList<Double>(maxElementsPerBuffer);
       }
       
       collapse(buffer.get(level), buf, merged);
@@ -373,7 +368,7 @@ public class StreamingQuantile extends AccumulatorEvalFunc<Tuple>
 
     public List<Double> getQuantiles()
     {
-      List<Double> quantiles = Lists.newArrayList();
+      List<Double> quantiles = new ArrayList<Double>();
       quantiles.add(min);
       
       if (buffer.get(0) != null) {

--- a/src/java/datafu/pig/stats/WilsonBinConf.java
+++ b/src/java/datafu/pig/stats/WilsonBinConf.java
@@ -17,6 +17,7 @@
 package datafu.pig.stats;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import org.apache.commons.math.MathException;
 import org.apache.commons.math.distribution.NormalDistribution;
@@ -27,8 +28,6 @@ import org.apache.pig.data.TupleFactory;
 import org.apache.pig.impl.logicalLayer.FrontendException;
 import org.apache.pig.impl.logicalLayer.schema.Schema;
 import org.apache.pig.impl.logicalLayer.schema.Schema.FieldSchema;
-
-import com.google.common.collect.ImmutableList;
 
 import datafu.pig.util.SimpleEvalFunc;
 
@@ -92,7 +91,7 @@ public class WilsonBinConf extends SimpleEvalFunc<Tuple>
     if (x > n)
       throw new IllegalArgumentException("invariant violation: number of successes > number of obs");
     if (n == 0)
-      return tupleFactory.newTuple(ImmutableList.of(Double.valueOf(0), Double.valueOf(0)));
+      return tupleFactory.newTuple(Arrays.asList(Double.valueOf(0), Double.valueOf(0)));
 
     try {
       double zcrit = -1.0 * normalDist.inverseCumulativeProbability(alpha/2);
@@ -117,7 +116,7 @@ public class WilsonBinConf extends SimpleEvalFunc<Tuple>
       if (x == (n - 1))
         upper = 1 + Math.log(1 - alpha)/n;
 
-      return tupleFactory.newTuple(ImmutableList.of(lower, upper));
+      return tupleFactory.newTuple(Arrays.asList(lower, upper));
     }
     catch (MathException e) {
       throw new IOException("math error", e);
@@ -128,7 +127,7 @@ public class WilsonBinConf extends SimpleEvalFunc<Tuple>
   public Schema outputSchema(Schema input)
   {
     try {
-      Schema innerSchema =  new  Schema(ImmutableList.of(
+      Schema innerSchema =  new  Schema(Arrays.asList(
               new Schema.FieldSchema("lower", DataType.DOUBLE),
               new Schema.FieldSchema("upper", DataType.DOUBLE)));
 


### PR DESCRIPTION
I wanted to remove Guava as a dependency in our pom.  This makes DataFu easier to use.  We are not using very many parts of Guava.  So, I tried autojarring it, which packages Guava in DataFu and includes only what we need (followed by jarjar to rename the packages).  This ended up pulling in a lot of Guava, as we were using ImmutableList in several places, which apparently has many downstream dependencies in the JAR.  I replaced these calls in DataFu with Arrays calls.  Arrays ships with Java.  Now there is just a handful of classes we pull in from Guava.  The file size is not significantly changed as a result.  The only dependency now in our pom is joda-time.
